### PR TITLE
Use configurable paths in start scripts

### DIFF
--- a/Ray_Start.m
+++ b/Ray_Start.m
@@ -13,13 +13,16 @@
 clear;clc;
 % close all;
 
-% path= 'C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray';
-path = 'D:\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray';
+% Load project directories from configuration
+if ~exist('settings','var') || ~isstruct(settings)
+    settings = project_settings();
+end
+path = settings.root;
 
 addpath(path);
-addpath([path,'\Funzioni\'])
-addpath([path,'\Dati Caomsol\'])
-addpath([path,'\Class\'])
+addpath(settings.functions)
+addpath(settings.data)
+addpath(settings.class)
 
 tic
 % Import material file
@@ -89,7 +92,7 @@ ray   = c_Rays();
 video = 'off';
 
 if strcmp(video,'on')
-    path_dave = ('D:\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\');
+    path_dave = settings.results;
     v = VideoWriter([path_dave,'G4s_BOX_W_vero.mp4'],'MPEG-4');
     open(v);
 end

--- a/Ray_Start_Roberto_001.m
+++ b/Ray_Start_Roberto_001.m
@@ -13,13 +13,17 @@
 clear;clc;
 % close all;
 tic
-% path= 'C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray';
-path = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\';
+
+% Load project directories from configuration
+if ~exist('settings','var') || ~isstruct(settings)
+    settings = project_settings();
+end
+path = settings.root;
 
 addpath(path);
-addpath([path,'\Funzioni\'])
-addpath([path,'\Dati Caomsol\'])
-addpath([path,'\Class\'])
+addpath(settings.functions)
+addpath(settings.data)
+addpath(settings.class)
 
 
 % Import material file
@@ -76,15 +80,15 @@ ray   = c_Rays();
 video = 'off';
 
 if strcmp(video,'on')
-    path_dave = ('C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\');
+    path_dave = settings.results;
     v = VideoWriter([path_dave,'G4s_BOX_W_vero.mp4'],'MPEG-4');
     open(v);
 end
 
 %%
 %  t_launch = utc2mjd([2014 08 22 12 27 00]));   % effemeridi iniziali di E18
-addpath('C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Box_wing\Confronto Box Wing Surf Surf_Visco\Script di Confronto\Massimo_risultati');
-path_save = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+addpath(settings.boxWingResults);
+path_save = settings.results;
 
 deltaT = dminutes * 1/24/60;
 % days   = 0.1;
@@ -249,7 +253,7 @@ currentHour = datestr(now, 'HHMMSS');
 % Combina la data e l'ora per formare il nome del file
 fileName = sprintf([Sat_inp.Box ,'.mat']);
 % Ora puoi salvare i tuoi dati utilizzando questo nome del file
-pat_res = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+pat_res = settings.results;
 
 % save([pat_res,fileName], 'ACC','SRP_body','Sat_b','ray_b');
 ora = datestr(now,'mmmm_dd_yyyy_ HH_MM_SS');
@@ -552,7 +556,7 @@ function save_data_geodine(desc,t,SRP_ECI,nomefile,Note)
 % ...
 % <tempo_iso_n> <acc_x_n> <acc_y_n> <acc_z_n>
 
-path_save = 'D:\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+path_save = settings.results;
 File_n = [desc{1,1},'_',nomefile,'.acc_est.asc'];
 Filename = [path_save,File_n];
 
@@ -639,7 +643,7 @@ function save_data_geodine_quatrnion(desc,t,ACC,nomefile,Note)
 % #              tempo_iso - Tempo del campione nel formato ISO (e.g. 2001-01-01T00:00:00.000)
 % #              q_1, q_2, q_3, q_4 - Componenti del quaternione assetto
 
-path_save = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+path_save = settings.results;
 File_n = [desc{1,1},'_',nomefile,'.att_est.asc'];
 Filename = [path_save,File_n];
 

--- a/Ray_Start_Roberto_002.m
+++ b/Ray_Start_Roberto_002.m
@@ -13,13 +13,16 @@
 clear;clc;
 close all;
 
-% path= 'C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray';
-path = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\';
+% Load project directories from configuration
+if ~exist('settings','var') || ~isstruct(settings)
+    settings = project_settings();
+end
+path = settings.root;
 
 addpath(path);
-addpath([path,'\Funzioni\'])
-addpath([path,'\Dati Caomsol\'])
-addpath([path,'\Class\'])
+addpath(settings.functions)
+addpath(settings.data)
+addpath(settings.class)
 
 
 % Import material file
@@ -77,15 +80,15 @@ ray   = c_Rays();
 video = 'off';
 
 if strcmp(video,'on')
-    path_dave = ('C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\');
+    path_dave = settings.results;
     v = VideoWriter([path_dave,'G4s_BOX_W_vero.mp4'],'MPEG-4');
     open(v);
 end
 
 %%
 %  t_launch = utc2mjd([2014 08 22 12 27 00]));   % effemeridi iniziali di E18
-addpath('C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Box_wing\Confronto Box Wing Surf Surf_Visco\Script di Confronto\Massimo_risultati');
-path_save = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+addpath(settings.boxWingResults);
+path_save = settings.results;
 
 deltaT = dminutes * 1/24/60;
 % days   = 0.1;
@@ -94,7 +97,7 @@ deltaT = dminutes * 1/24/60;
 init_Cond = Generazione_coordinate_Satellite_sole('E18' ...
     ,deltaT,days) % (satellite,dt,day_long)
 
-file_SUN = dir(['C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\','Sun_Body_dir*'])
+file_SUN = dir(fullfile(settings.results,'Sun_Body_dir*'))
 
 load([path_save,file_SUN(end).name]);
 
@@ -283,7 +286,7 @@ currentHour = datestr(now, 'HHMMSS');
 % Combina la data e l'ora per formare il nome del file
 fileName = sprintf([Sat_inp.Box ,'.mat']);
 % Ora puoi salvare i tuoi dati utilizzando questo nome del file
-pat_res = 'C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+pat_res = settings.results;
 
 % save([pat_res,fileName], 'ACC','SRP_body','Sat_b','ray_b');
 ora = datestr(now,'mmmm_dd_yyyy_ HH_MM_SS');
@@ -539,7 +542,7 @@ function save_data_geodine(desc,t,SRP_ECI,nomefile,Note)
 % ...
 % <tempo_iso_n> <acc_x_n> <acc_y_n> <acc_z_n>
 
-path_save = 'C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+path_save = settings.results;
 File_n = join(strrep([desc{1,1},'_',nomefile,'.acc_est.asc'],' ', ''));
 Filename = join([path_save,File_n]);  
 
@@ -627,7 +630,7 @@ function save_data_geodine_quatrnion(desc,t,ACC,nomefile,Note)
 % #              tempo_iso - Tempo del campione nel formato ISO (e.g. 2001-01-01T00:00:00.000)
 % #              q_1, q_2, q_3, q_4 - Componenti del quaternione assetto
 
-path_save = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+path_save = settings.results;
 File_n = [desc{1,1},'_',nomefile,'.att_est.asc'];
 Filename = [path_save,File_n];
 

--- a/Ray_Start_Roberto_002_local.m
+++ b/Ray_Start_Roberto_002_local.m
@@ -13,13 +13,16 @@
 clear;clc;
 close all;
 
-% path= 'C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray';
-path = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\';
+% Load project directories from configuration
+if ~exist('settings','var') || ~isstruct(settings)
+    settings = project_settings();
+end
+path = settings.root;
 
 addpath(path);
-addpath([path,'\Funzioni\'])
-addpath([path,'\Dati Caomsol\'])
-addpath([path,'\Class\'])
+addpath(settings.functions)
+addpath(settings.data)
+addpath(settings.class)
 
 
 % Import material file
@@ -78,15 +81,15 @@ ray   = c_Rays();
 video = 'off';
 
 if strcmp(video,'on')
-    path_dave = fullfile(path, 'Results\');
+    path_dave = settings.results;
     v = VideoWriter(fullfile(path_dave, 'G4s_BOX_W_vero.mp4'), 'MPEG-4');
     open(v);
 end
 
 %%
 %  t_launch = utc2mjd([2014 08 22 12 27 00]));   % effemeridi iniziali di E18
-addpath('C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Box_wing\Confronto Box Wing Surf Surf_Visco\Script di Confronto\Massimo_risultati');
-path_save = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+addpath(settings.boxWingResults);
+path_save = settings.results;
 
 deltaT = dminutes * 1/24/60;
 % days   = 0.1;
@@ -292,8 +295,7 @@ currentHour = datestr(now, 'HHMMSS');
 % Combina la data e l'ora per formare il nome del file
 fileName = sprintf([Sat_inp.Box ,'.mat']);
 % Ora puoi salvare i tuoi dati utilizzando questo nome del file
-pat_res = 'C:\Users\carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
-
+pat_res = settings.results;
 % save([pat_res,fileName], 'ACC','SRP_body','Sat_b','ray_b');
 ora = datestr(now,'mmmm_dd_yyyy_ HH_MM_SS');
 % save([pat_res,'Foc3_Ansys_materials_5_SA_2min_7dd_1ref_SAT_ray',ora,'.mat'],'Sat_b','ray_b','-v7.3','-nocompression');
@@ -607,7 +609,7 @@ function save_data_geodine(desc,t,SRP_ECI,nomefile,Note)
 % ...
 % <tempo_iso_n> <acc_x_n> <acc_y_n> <acc_z_n>
 
-path_save = 'D:\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+path_save = settings.results;
 File_n = [desc{1,1},'_',nomefile,'.acc_est.asc'];
 Filename = [path_save,File_n];
 
@@ -694,7 +696,7 @@ function save_data_geodine_quatrnion(desc,t,ACC,nomefile,Note)
 % #              tempo_iso - Tempo del campione nel formato ISO (e.g. 2001-01-01T00:00:00.000)
 % #              q_1, q_2, q_3, q_4 - Componenti del quaternione assetto
 
-path_save = 'C:\Users\Carlo\OneDrive - INAF - Istituto Nazionale di Astrofisica\G4S\Matlab_ray\Results\';
+path_save = settings.results;
 File_n = [desc{1,1},'_',nomefile,'.att_est.asc'];
 Filename = [path_save,File_n];
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "root": "D:/OneDrive - INAF - Istituto Nazionale di Astrofisica/G4S/Matlab_ray"
+}

--- a/project_settings.m
+++ b/project_settings.m
@@ -1,0 +1,47 @@
+function settings = project_settings(varargin)
+%PROJECT_SETTINGS  Load project directory configuration.
+%   SETTINGS = PROJECT_SETTINGS() returns a structure with commonly used
+%   directories for the ray tracing project. The function looks for a
+%   'config.json' file located in the same folder and reads the field
+%   'root' to determine the root directory. The root can also be passed as
+%   a name-value pair argument:
+%       SETTINGS = PROJECT_SETTINGS('root', ROOTDIR)
+%
+%   The returned structure contains the following fields:
+%       .root      - project root directory
+%       .functions - path to the 'Funzioni' folder
+%       .data      - path to 'Dati Caomsol'
+%       .class     - path to 'Class'
+%       .results   - path to 'Results'
+%       .boxWingResults - path to 'Box_wing/Confronto Box Wing Surf .../Massimo_risultati'
+%
+%   Using this helper avoids hard-coded absolute paths inside the start
+%   scripts.
+
+p = inputParser;
+p.addParameter('root','',@ischar);
+p.parse(varargin{:});
+settings.root = p.Results.root;
+
+if isempty(settings.root)
+    cfgFile = fullfile(fileparts(mfilename('fullpath')),'config.json');
+    if exist(cfgFile,'file')
+        cfg = jsondecode(fileread(cfgFile));
+        if isfield(cfg,'root')
+            settings.root = cfg.root;
+        end
+    end
+end
+
+if isempty(settings.root)
+    settings.root = pwd; % fallback
+end
+
+settings.functions = fullfile(settings.root,'Funzioni');
+settings.data      = fullfile(settings.root,'Dati Caomsol');
+settings.class     = fullfile(settings.root,'Class');
+settings.results   = fullfile(settings.root,'Results');
+settings.boxWingResults = fullfile(settings.root,'Box_wing', ...
+    'Confronto Box Wing Surf Surf_Visco', 'Script di Confronto', ...
+    'Massimo_risultati');
+end


### PR DESCRIPTION
## Summary
- add a `project_settings` helper that reads paths from `config.json`
- use the new settings struct in `Ray_Start.m`
- use the new settings struct in `Ray_Start_Roberto_001.m`
- use the new settings struct in `Ray_Start_Roberto_002.m`
- use the new settings struct in `Ray_Start_Roberto_002_local.m`
- provide a sample `config.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff4212fe08322a5f15ae7cf351a5e